### PR TITLE
SLICE_SHOW EP in Front- und Backend registrieren

### DIFF
--- a/plugins/status/lib/bloecks_status.php
+++ b/plugins/status/lib/bloecks_status.php
@@ -20,11 +20,8 @@ class bloecks_status extends bloecks_abstract
             // call the backend functions
             bloecks_status_backend::init($ep);
         }
-        else if(!rex::isBackend())
-        {
-            // add our slice_show extension whenever a sliceis displayed
-            rex_extension::register('SLICE_SHOW_BLOECKS_FE', array('bloecks_status', 'showSlice'));
-        }
+        // add our slice_show extension whenever a sliceis displayed
+        rex_extension::register('SLICE_SHOW_BLOECKS_FE', array('bloecks_status', 'showSlice'));
     }
 
     /**


### PR DESCRIPTION
Der EP darf nicht nur im Frontend registriert werden, da auch AddOns, z.B. der "cache_warmup" im Backend einen Artikel-Cache erstellen können. Hab richtig Ärger mit dem Kunden bekommen, weil sensible Slices plötzlich online waren. Da ich den Content nicht kannte, ist es mir nicht aufgefallen.

Nach diversen Debugs hab ich das dann herausgefunden. Bitte mergen und schnell ein Update pushen!

https://github.com/FriendsOfREDAXO/cache_warmup/issues/65