### PR TITLE
Slice-Status über neuen EP-Param abfragen

### DIFF
--- a/plugins/status/lib/bloecks_status.php
+++ b/plugins/status/lib/bloecks_status.php
@@ -34,7 +34,16 @@ class bloecks_status extends bloecks_abstract
      */
     public static function showSlice(rex_extension_point $ep)
     {
-        $status = (bool) static::getValueOfSlice($ep->getParam('slice_id'), 'status', 1);
+        if ($ep->hasParam('sql'))
+        {
+            /** @var rex_sql $sql */
+            $sql = $ep->getParam('sql');
+            $status = (bool) $sql->getValue('status');
+        }
+        else
+        {
+            $status = (bool) static::getValueOfSlice($ep->getParam('slice_id'), 'status', 1);
+        }
         if($status === false)
         {
             // slice is not active - don't show anything!

--- a/plugins/status/lib/bloecks_status_backend.php
+++ b/plugins/status/lib/bloecks_status_backend.php
@@ -178,7 +178,16 @@ class bloecks_status_backend extends bloecks_backend
     {
         $subject = $ep->getSubject();
 
-        $status = (bool) static::getValueOfSlice($ep->getParam('slice_id'), 'status', 1);
+        if ($ep->hasParam('sql'))
+        {
+            /** @var rex_sql $sql */
+            $sql = $ep->getParam('sql');
+            $status = (bool) $sql->getValue('status');
+        }
+        else
+        {
+            $status = (bool) static::getValueOfSlice($ep->getParam('slice_id'), 'status', 1);
+        }
         if($status === false)
         {
             return str_replace('class="rex-slice rex-slice-output"','class="rex-slice rex-slice-output rex-slice-status-off"', $subject);


### PR DESCRIPTION
https://github.com/redaxo/redaxo/issues/1206

Leider konnten wir das Problem nicht allein im Core bzw. History-Plugin lösen.
Problem ist, dass bloecks immer noch mal frisch den Status aus der DB abfragt. Wenn man sich aber historische Stände anschaut, sind diese Slices aber gar nicht in der normalen Tabelle vorhanden.

Daher gibt es nun beim EP `SLICE_SHOW` einen neuen Param `sql`, der das ganze SQL-Objekt liefert, über das man direkt die Werte abfragen kann.

Da es das erst mit R 5.4 geben wird, habe ich als Kompatibilität die andere Abfragemethode drin gelassen.