### PR TITLE
Min rex version anheben

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: bloecks
-version: '1.3.14'
+version: '1.3.15'
 author: 'Friends Of REDAXO'
 supportpage: https://github.com/FriendsOfREDAXO/bloecks
 

--- a/package.yml
+++ b/package.yml
@@ -12,4 +12,4 @@ page:
 requires:
     packages:
         structure/content: '>=2.1.0'
-    redaxo: ^5.2.0
+    redaxo: ^5.5.0


### PR DESCRIPTION
Da die in https://github.com/FriendsOfREDAXO/bloecks/commit/566f2c7c98bceb4c6751543c99dc282ed45a221b verwendete klasse rex_csrf_token erst seit redsaxo 5.5.0 existiert