### PR TITLE
feat: update inserted slice status

### DIFF
--- a/plugins/cutncopy/lib/bloecks_cutncopy_backend.php
+++ b/plugins/cutncopy/lib/bloecks_cutncopy_backend.php
@@ -211,13 +211,15 @@ class bloecks_cutncopy_backend extends bloecks_backend
             }
             else
             {
-                static::setCookie(['slice_id' => $slice->getId(), 'clang' => $slice->getClang(), 'revision' => $slice->getRevision(), 'action' => 'copy']);
+                $status = static::getValueOfSlice($slice->getId(), 'status', 1);
+                static::setCookie(['slice_id' => $slice->getId(), 'clang' => $slice->getClang(), 'revision' => $slice->getRevision(), 'status' => $status, 'action' => 'copy']);
 
                 rex_extension::registerPoint(new rex_extension_point('SLICE_COPIED', '', [
                     'slice_id' => $slice->getId(),
                     'article_id' => $slice->getArticleId(),
                     'clang_id' => $slice->getClang(),
                     'slice_revision' => $slice->getRevision(),
+                    'status' => $status,
                     'cutncopy-action' => 'copy'
                 ]));
 
@@ -245,13 +247,15 @@ class bloecks_cutncopy_backend extends bloecks_backend
             }
             else
             {
-                static::setCookie(['slice_id' => $slice->getId(), 'clang' => $slice->getClang(), 'revision' => $slice->getRevision(), 'action' => 'cut']);
+                $status = static::getValueOfSlice($slice->getId(), 'status', 1);
+                static::setCookie(['slice_id' => $slice->getId(), 'clang' => $slice->getClang(), 'revision' => $slice->getRevision(), 'status' => $status, 'action' => 'cut']);
 
                 rex_extension::registerPoint(new rex_extension_point('SLICE_CUT', '', [
                     'slice_id' => $slice->getId(),
                     'article_id' => $slice->getArticleId(),
                     'clang_id' => $slice->getClang(),
                     'slice_revision' => $slice->getRevision(),
+                    'status' => $status,
                     'cutncopy-action' => 'cut'
                 ]));
 
@@ -349,8 +353,10 @@ class bloecks_cutncopy_backend extends bloecks_backend
                     rex_extension::registerPoint(new rex_extension_point('SLICE_INSERTED', '', [
                         'source_slice_id' => static::$clipboard_slice,
                         'before_slice_id' => rex_request('slice_id', 'int', null),
+                        'inserted_slice_id' => (int) $ep->getParam('slice_id'),
                         'clang_id' => static::$clipboard_slice->getClang(),
                         'slice_revision' => static::$clipboard_slice->getRevision(),
+                        'status' => static::getCookie('status', 'int', 1),
                         'cutncopy-action' => $action
                     ]));
 

--- a/plugins/status/lib/bloecks_status_backend.php
+++ b/plugins/status/lib/bloecks_status_backend.php
@@ -24,6 +24,9 @@ class bloecks_status_backend extends bloecks_backend
         // register action for display of the slice
         rex_extension::register('SLICE_SHOW_BLOECKS_BE', array('bloecks_status_backend', 'showSlice'));
 
+        // register action for updating an inserted slice status
+        rex_extension::register('SLICE_INSERTED', array('bloecks_status_backend', 'updateSliceStatus'));
+
         // call the addon init function - see blocks_backend:init() class
         parent::init($ep);
     }
@@ -195,4 +198,22 @@ class bloecks_status_backend extends bloecks_backend
         return $subject;
     }
 
+    /**
+     * Updates an inserted slice status
+     * @param  rex_extension_point $ep [description]
+     * @return string                  the slice content
+     */
+    public static function updateSliceStatus(rex_extension_point $ep)
+    {
+        $slice_id = $ep->getParam('inserted_slice_id');
+        $clang = $ep->getParam('clang_id');
+        $revision = $ep->getParam('slice_revision');
+        $status = $ep->getParam('status');
+        $cutncopyAction = $ep->getParam('cutncopy-action');
+
+        if ('copy' === $cutncopyAction || 'cut' === $cutncopyAction)
+        {
+            static::setSliceStatus($slice_id, $clang, $revision, $status);
+        }
+    }
 }


### PR DESCRIPTION
- cutncopy plugin: save slice status on cut and copy actions, inject status into SLICE_INSERTED EP
- status plugin: hook on SLICE_INSERTED EP to update slice status

fixes #45