### PR TITLE
Fix permissions management

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -13,7 +13,6 @@ rex_api_function::register('bloecks', Api::class);
 
 // Register permissions
 rex_perm::register('bloecks[]');
-rex_perm::register('bloecks[settings]');
 rex_perm::register('bloecks[copy]');
 rex_perm::register('bloecks[order]');
 
@@ -21,18 +20,8 @@ rex_perm::register('bloecks[order]');
 if (rex::isBackend() && PHP_SAPI !== 'cli') {
     // Only run session-dependent code when not in CLI context
     rex_extension::register('PACKAGES_INCLUDED', static function () {
-        $addon = rex_addon::get('bloecks');
-
         // Clear clipboard on login/logout and session start for security
         Backend::clearClipboardOnSessionStart();
         Backend::init();
-
-        // Register wrapper for slice_columns-style drag & drop only if enabled
-        if ($addon->getConfig('enable_drag_drop', false)) {
-            rex_extension::register('SLICE_SHOW', Wrapper::addDragDropWrapper(...), rex_extension::EARLY);
-            rex_extension::register('SLICE_MENU', Wrapper::addDragHandle(...));
-            // error_log("BLOECKS DEBUG: Drag & Drop extension points registered");
-        }
-        // error_log("BLOECKS DEBUG: Drag & Drop disabled, no wrapper extension points registered");
     });
 }

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -17,6 +17,11 @@ bloecks_disabled = Deaktiviert
 bloecks_drag_move = Slice verschieben
 bloecks_drag_handle = Verschieben
 
+# Permissions
+perm_general_bloecks[] = Vollzugriff auf alle blÖcks-Features
+perm_general_bloecks[copy] = Slices kopieren und einfügen
+perm_general_bloecks[order] = Slices per Drag & Drop sortieren
+
 # Copy/Cut/Paste functionality
 bloecks_copy_slice = Slice kopieren
 bloecks_cut_slice = Slice ausschneiden

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -17,6 +17,11 @@ bloecks_disabled = Disabled
 bloecks_drag_move = Move slice
 bloecks_drag_handle = Move
 
+# Permissions
+perm_general_bloecks[] = Full access to all blÖcks features
+perm_general_bloecks[copy] = Copy and paste slices
+perm_general_bloecks[order] = Reorder slices via drag & drop
+
 # Copy/Cut/Paste functionality
 bloecks_copy_slice = Copy slice
 bloecks_cut_slice = Cut slice

--- a/lang/es_es.lang
+++ b/lang/es_es.lang
@@ -17,6 +17,11 @@ bloecks_disabled = Deshabilitado
 bloecks_drag_move = Mover slice
 bloecks_drag_handle = Mover
 
+# Permissions
+perm_general_bloecks[] = Acceso completo a todas las funciones de blÖcks
+perm_general_bloecks[copy] = Copiar y pegar slices
+perm_general_bloecks[order] = Reordenar slices mediante arrastrar y soltar
+
 # Copy/Cut/Paste functionality
 bloecks_copy_slice = Copiar slice
 bloecks_cut_slice = Cortar slice

--- a/lang/fi_fi.lang
+++ b/lang/fi_fi.lang
@@ -11,6 +11,28 @@ bloecks_csv_notice = Pilkuilla erotettu lista ID:istä
 bloecks_no_permission = Ei käyttöoikeutta
 bloecks_feat_copy = Kopioi, leikkaa ja liitä slicejä
 bloecks_feat_order = Järjestä slicejä uudelleen vetämällä ja pudottamalla
+bloecks_intro = Kevyt työkalu slicejen kopiointiin/liittämiseen, leikkaamiseen ja vetämiseen/pudottamiseen.
+bloecks_enabled = Käytössä
+bloecks_disabled = Ei käytössä
+bloecks_drag_move = Siirrä slice
+bloecks_drag_handle = Siirrä
+
+# Permissions
+perm_general_bloecks[] = Täysi pääsy kaikkiin blÖcks-ominaisuuksiin
+perm_general_bloecks[copy] = Kopioi ja liitä slicejä
+perm_general_bloecks[order] = Järjestä slicejä vetämällä ja pudottamalla = blÖcks
+bloecks_overview = Yleiskatsaus
+bloecks_settings = Asetukset
+bloecks_docs = Dokumentaatio
+bloecks_enable_copy_paste = Ota käyttöön Kopioi & Liitä
+bloecks_enable_drag_drop = Ota käyttöön Vedä & Pudota
+bloecks_active = aktiivinen
+bloecks_templates_exclude = Jätä pois mallien ID:t
+bloecks_modules_exclude = Jätä pois moduulien ID:t
+bloecks_csv_notice = Pilkuilla erotettu lista ID:istä
+bloecks_no_permission = Ei käyttöoikeutta
+bloecks_feat_copy = Kopioi, leikkaa ja liitä slicejä
+bloecks_feat_order = Järjestä slicejä uudelleen vetämällä ja pudottamalla
 bloecks_intro = Kevyt työkalu slicejen kopiointiin/liittämiseen, leikkaamiseen ja vetämiseen & pudottamiseen.
 bloecks_enabled = Käytössä
 bloecks_disabled = Pois käytöstä

--- a/lang/fr_fr.lang
+++ b/lang/fr_fr.lang
@@ -17,6 +17,11 @@ bloecks_disabled = Désactivé
 bloecks_drag_move = Déplacer la slice
 bloecks_drag_handle = Déplacer
 
+# Permissions
+perm_general_bloecks[] = Accès complet à toutes les fonctionnalités blÖcks
+perm_general_bloecks[copy] = Copier et coller des slices
+perm_general_bloecks[order] = Réorganiser les slices par glisser-déposer
+
 # Copy/Cut/Paste functionality
 bloecks_copy_slice = Copier la slice
 bloecks_cut_slice = Couper la slice

--- a/lang/it_it.lang
+++ b/lang/it_it.lang
@@ -17,6 +17,11 @@ bloecks_disabled = Disabilitato
 bloecks_drag_move = Sposta slice
 bloecks_drag_handle = Sposta
 
+# Permissions
+perm_general_bloecks[] = Accesso completo a tutte le funzionalità blÖcks
+perm_general_bloecks[copy] = Copia e incolla slice
+perm_general_bloecks[order] = Riordina slice tramite trascinamento
+
 # Copy/Cut/Paste functionality
 bloecks_copy_slice = Copia slice
 bloecks_cut_slice = Taglia slice

--- a/lang/pl_pl.lang
+++ b/lang/pl_pl.lang
@@ -17,6 +17,11 @@ bloecks_disabled = Wyłączony
 bloecks_drag_move = Przesuń slice
 bloecks_drag_handle = Przesuń
 
+# Permissions
+perm_general_bloecks[] = Pełny dostęp do wszystkich funkcji blÖcks
+perm_general_bloecks[copy] = Kopiuj i wklej slices
+perm_general_bloecks[order] = Zmieniaj kolejność slices przeciągając i upuszczając
+
 # Copy/Cut/Paste functionality
 bloecks_copy_slice = Kopiuj slice
 bloecks_cut_slice = Wytnij slice

--- a/lang/sv_se.lang
+++ b/lang/sv_se.lang
@@ -2,20 +2,25 @@ bloecks_navigation = blÖcks
 bloecks_overview = Översikt
 bloecks_settings = Inställningar
 bloecks_docs = Dokumentation
-bloecks_enable_copy_paste = Aktivera Kopiera & Klistra in
-bloecks_enable_drag_drop = Aktivera Dra & Släpp
+bloecks_enable_copy_paste = Aktivera kopiera och klistra in
+bloecks_enable_drag_drop = Aktivera dra och släpp
 bloecks_active = aktiv
-bloecks_templates_exclude = Uteslut mall-ID:n
-bloecks_modules_exclude = Uteslut modul-ID:n
+bloecks_templates_exclude = Exkludera mall-ID:n
+bloecks_modules_exclude = Exkludera modul-ID:n
 bloecks_csv_notice = Kommaseparerad lista med ID:n
 bloecks_no_permission = Ingen behörighet
-bloecks_feat_copy = Kopiera, klipp ut och klistra in slices
-bloecks_feat_order = Ordna om slices via dra & släpp
-bloecks_intro = Lättviktsverktyg för kopiera/klistra in, klipp ut och dra & släpp av slices.
+bloecks_feat_copy = Kopiera, klipp ut och klistra in avsnitt
+bloecks_feat_order = Ordna om avsnitt via dra och släpp
+bloecks_intro = Lätt verktyg för kopiera/klistra in, klipp ut och dra och släpp av avsnitt.
 bloecks_enabled = Aktiverad
 bloecks_disabled = Inaktiverad
-bloecks_drag_move = Flytta slice
+bloecks_drag_move = Flytta avsnitt
 bloecks_drag_handle = Flytta
+
+# Permissions
+perm_general_bloecks[] = Full åtkomst till alla blÖcks-funktioner
+perm_general_bloecks[copy] = Kopiera och klistra in avsnitt
+perm_general_bloecks[order] = Ordna om avsnitt via dra och släpp
 
 # Copy/Cut/Paste functionality
 bloecks_copy_slice = Kopiera slice

--- a/package.yml
+++ b/package.yml
@@ -5,7 +5,7 @@ supportpage: https://github.com/FriendsOfREDAXO/bloecks
 
 page:
     title: 'translate:bloecks_navigation'
-    perm: bloecks[]
+    perm: admin
     pjax: false
     icon: rex-icon fa-th-large
     subPath: settings.php

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -2,7 +2,7 @@
 
 /** @var rex_addon $this */
 
-if (!rex::getUser()->hasPerm('bloecks[settings]')) {
+if (!rex::getUser()->isAdmin()) {
     echo rex_view::error(rex_i18n::msg('bloecks_no_permission'));
     return;
 }


### PR DESCRIPTION
- Remove bloecks[settings] permission - admin only now
- Move all extension point registration to Backend::init()
- Add proper permission checks for drag & drop in boot.php
- Separate permissions for copy/paste (bloecks[copy]) and drag & drop (bloecks[order])
- Settings page now admin-only
- Clean up boot.php by moving logic to Backend class

Permissions structure:
- bloecks[] = full access to all features
- bloecks[copy] = copy/paste only
- bloecks[order] = drag & drop only
- Settings page = admin only