### PR TITLE
Hotfix 5.3.1: Syntax-Fehler in bloecks_api.php behoben

### DIFF
--- a/lib/bloecks_api.php
+++ b/lib/bloecks_api.php
@@ -347,9 +347,9 @@ class Api extends rex_api_function
                     if ($checkSql->getRows() > 0) {
                         $sourceArticleId = $checkSql->getValue('article_id');
                         $sourceClangId = $checkSql->getValue('clang_id');
-                        
+
                         rex_content_service::deleteSlice($srcId);
-                        
+
                         // Clear cache of source article so it disappears from frontend
                         rex_article_cache::delete($sourceArticleId, $sourceClangId);
                     }
@@ -570,14 +570,15 @@ class Api extends rex_api_function
                 if ($checkSql->getRows() > 0) {
                     $sourceArticleId = $checkSql->getValue('article_id');
                     $sourceClangId = $checkSql->getValue('clang_id');
-                    
+
                     rex_content_service::deleteSlice($srcId);
-                    
+
                     // Clear cache of source article so it disappears from frontend
                     // Only clear if source and target are different to avoid redundant cache clear
                     if ($sourceArticleId !== $articleId || $sourceClangId !== $clang) {
                         rex_article_cache::delete($sourceArticleId, $sourceClangId);
                     }
+                }
             }
         }
 

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: bloecks
-version: '5.3.0'
+version: '5.3.1'
 author: 'Friends Of REDAXO'
 supportpage: https://github.com/FriendsOfREDAXO/bloecks
 


### PR DESCRIPTION
## Problem
Nach dem Update auf Version 5.3.0 konnte die Kopier-/Einfüge-Funktion nicht mehr verwendet werden.

### Fehlermeldungen:
- Parse Error: `syntax error, unexpected token "private"` bei Zeile 587 in `bloecks_api.php`
- AJAX-Fehler: Netzwerkfehler bei der Verarbeitung
- Konsolen-Fehler: Could not load clipboard status

## Ursache
Beim Merge von PR #169 ging eine schließende geschweifte Klammer verloren, was zu einem PHP Parse Error führte.

## Lösung
- Fehlende schließende Klammer nach dem Cache-Löschungs-Block hinzugefügt (Zeile 581)
- Code-Style-Fixes angewendet (php-cs-fixer)
- Version auf 5.3.1 angehoben

## Tests
- ✅ PHP Syntax-Check: Alle 16 PHP-Dateien fehlerfrei
- ✅ PHP-CS-Fixer: Alle Dateien entsprechen den Coding Standards

Fixes #173