### PR TITLE
Update backend/console check to use environment instead of SAPI

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -17,7 +17,7 @@ rex_perm::register('bloecks[order]');
 rex_perm::register('bloecks[multi]');
 
 // Backend functionality
-if (rex::isBackend() && PHP_SAPI !== 'cli') {
+if (rex::isBackend() && rex::getEnvironment() != 'console') {
     // Only run session-dependent code when not in CLI context
     rex_extension::register('PACKAGES_INCLUDED', static function () {
         // Clear clipboard on login/logout and session start for security


### PR DESCRIPTION
`PHP_SAPI !== 'cli'` was/is nmot reliable enough to seperate console calls from regular backend access

Issue occured because bloecks resets session later if that `if` is passed. That stops console calls some steps later.