### PR TITLE
Fix: Fehler-Toasts erfassen fremde Alerts wegen unqualifiziertem Selektor

### DIFF
--- a/assets/js/bloecks.js
+++ b/assets/js/bloecks.js
@@ -323,7 +323,14 @@ var BLOECKS = (function($) {
             duration = duration || 4000;
             // Only select alerts that were explicitly marked as BLOECKS-owned by the PHP backend.
             // This prevents accidentally converting alerts from other AddOns into toasts.
-            var bloecksSelector = selector + '.bloecks-message, ' + selector + '[data-bloecks-message="1"]';
+            // Each base selector must be qualified individually: concatenating a
+            // comma-containing selector (e.g. '.alert-danger, .alert-error') would leave
+            // the first group unqualified and match every foreign alert on the page.
+            var baseSelectors = (typeof selector === 'string') ? selector.split(',') : selector;
+            var bloecksSelector = baseSelectors.map(function (sel) {
+                sel = sel.trim();
+                return sel + '.bloecks-message, ' + sel + '[data-bloecks-message="1"]';
+            }).join(', ');
             var alerts = mainContent.querySelectorAll(bloecksSelector);
             
             alerts.forEach(function(alert) {


### PR DESCRIPTION
Bei der Toast-Erkennung soll `processAlerts()` in `assets/js/bloecks.js` per `.bloecks-message`-Guard **nur** bloecks-eigene Alerts in Toasts umwandeln. Für Fehler-Alerts funktioniert der Guard aber nicht.

## Problem

Der Guard wird per String-Konkatenation gebaut:

```js
var bloecksSelector = selector + ".bloecks-message, " + selector + "[data-bloecks-message=\"1\"]";
```

Der Aufruf für Fehler-Alerts übergibt einen **komma-getrennten** Selektor:

```js
processAlerts(".alert-danger, .alert-error", "error", 5000);
```

Damit ergibt die Konkatenation:

```
.alert-danger, .alert-error.bloecks-message, .alert-danger, .alert-error[data-bloecks-message="1"]
```

Als Selektor-Gruppen gelesen ist die **erste** Gruppe das nackte, unqualifizierte `.alert-danger` → `querySelectorAll` erfasst **jeden** roten Alert der Seite, auch von Fremd-AddOns.

`.alert-success` und `.alert-warning` sind nicht betroffen, weil dort kein Komma im Selektor steht und der Guard korrekt greift.

## Reproduktion

Ein Backend-Benutzer ohne das ycom-Recht `ycomArticlePermissions[]` sieht in der Content-Sidebar den (schreibgeschützten) ycom-Auth-Hinweis `<p class="alert alert-danger">Keine Editierrechte</p>`. bloecks wandelt diesen fremden Alert beim Laden/PJAX der Content-Seite fälschlich in einen roten Fehler-Toast um:
<img width="410" height="100" alt="Bildschirmfoto 2026-07-21 um 21 40 16" src="https://github.com/user-attachments/assets/c95c328a-6955-4b78-bcf1-1a06d1c716d4" />

## Fix

Jeden Basis-Selektor **einzeln** mit dem `.bloecks-message`-Guard qualifizieren, statt einen komma-behafteten String zu konkatenieren. Verhalten für `.alert-success`/`.alert-warning` bleibt unverändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)